### PR TITLE
Remove unnecessary prototypes; clang in XCode 5.1 complains about duplic...

### DIFF
--- a/SVProgressHUD/SVProgressHUD.m
+++ b/SVProgressHUD/SVProgressHUD.m
@@ -41,22 +41,6 @@ CGFloat SVProgressHUDRingThickness = 6;
 
 @property (nonatomic, readonly) CGFloat visibleKeyboardHeight;
 
-- (void)showProgress:(float)progress
-              status:(NSString*)string
-            maskType:(SVProgressHUDMaskType)hudMaskType;
-
-- (void)showImage:(UIImage*)image
-           status:(NSString*)status
-         duration:(NSTimeInterval)duration;
-
-- (void)dismiss;
-
-- (void)setStatus:(NSString*)string;
-- (void)registerNotifications;
-- (void)moveToPoint:(CGPoint)newCenter rotateAngle:(CGFloat)angle;
-- (void)positionHUD:(NSNotification*)notification;
-- (NSTimeInterval)displayDurationForString:(NSString*)string;
-
 #if __IPHONE_OS_VERSION_MIN_REQUIRED < 50000
 - (UIColor *)hudBackgroundColor;
 - (UIColor *)hudForegroundColor;


### PR DESCRIPTION
...ate declarations if two methods share the same name, but one is static and the other is instance, and one prototype lives in the header while the other lives in the impl. Go figure.

Also, I'm too lazy to make a Whistle repo tonight.
